### PR TITLE
Support of default colors for each sonic

### DIFF
--- a/lua/sonicsd/cl_options.lua
+++ b/lua/sonicsd/cl_options.lua
@@ -4,6 +4,7 @@ local checkbox_options={
 	{"Sound", "sonic_sound"},
 	{"Particle light", "sonic_light"},
 	{"Dynamic light", "sonic_dynamiclight"},
+	{"Enable default colors for each sonic", "sonic_should_set_default_colors"},
 }
 
 for k,v in pairs(checkbox_options) do

--- a/lua/sonicsd/sh_sonics.lua
+++ b/lua/sonicsd/sh_sonics.lua
@@ -11,7 +11,8 @@ function SonicSD:AddSonic(t)
 	end
 
 	local wep = {}
-	wep.Category = "Doctor Who - Sonic Tools"
+	wep.Category = DEBUG_SONICSD_SPAWNMENU_CATEGORY_OVERRIDE or "Doctor Who - Sonic Tools"
+
 	wep.PrintName = t.Name
 	wep.ClassName = t.ID
 	if file.Exists("materials/vgui/weapons/sonic/"..t.ID..".vtf", "GAME") then

--- a/lua/sonicsd/sh_sonics.lua
+++ b/lua/sonicsd/sh_sonics.lua
@@ -4,6 +4,7 @@ SonicSD.sonics={}
 function SonicSD:AddSonic(t)
 	local base = table.Copy(self.sonics[t.Base] or self.sonics.default)
 	if base then
+		base.DefaultLightColor = nil -- not to be inherited
 		table.Merge(base,t)
 		self.sonics[t.ID]=base
 	else

--- a/lua/sonicsd/sonics/default.lua
+++ b/lua/sonicsd/sonics/default.lua
@@ -5,5 +5,6 @@ SonicSD:AddSonic({
 	WorldModel="models/weapons/w_sonicsd.mdl",
 	LightPos=Vector(20,-1.75,-2.75),
 	LightBrightness=5,
-	SoundLoop = "sonicsd/loop.wav"
+	SoundLoop = "sonicsd/loop.wav",
+	DefaultLightColor = Color(0, 100, 0)
 })

--- a/lua/sonicsd/sonics/default.lua
+++ b/lua/sonicsd/sonics/default.lua
@@ -1,10 +1,10 @@
 SonicSD:AddSonic({
-	ID="default",
-	Name="2010 Screwdriver",
-	ViewModel="models/weapons/c_sonicsd.mdl",
-	WorldModel="models/weapons/w_sonicsd.mdl",
-	LightPos=Vector(20,-1.75,-2.75),
-	LightBrightness=5,
+	ID = "default",
+	Name = "2010 Screwdriver",
+	ViewModel = "models/weapons/c_sonicsd.mdl",
+	WorldModel = "models/weapons/w_sonicsd.mdl",
+	LightPos = Vector(20,-1.75,-2.75),
+	LightBrightness = 5,
 	SoundLoop = "sonicsd/loop.wav",
 	DefaultLightColor = Color(0, 100, 0)
 })

--- a/lua/sonicsd/sonics/extended.lua
+++ b/lua/sonicsd/sonics/extended.lua
@@ -4,7 +4,8 @@ SonicSD:AddSonic({
 	ViewModel="models/doctor_who/sonic_screwdriver/c_10thsonicsd.mdl",
 	WorldModel="models/doctor_who/sonic_screwdriver/w_10thsonicsd.mdl",
 	LightPos=Vector(20,-2.5,-3.15),
-	LightBrightness=2
+	LightBrightness=2,
+	DefaultLightColor = Color(0, 180, 200)
 })
 
 SonicSD:AddSonic({

--- a/lua/sonicsd/sonics/extended.lua
+++ b/lua/sonicsd/sonics/extended.lua
@@ -1,17 +1,17 @@
 SonicSD:AddSonic({
-	ID="10th-slogan",
-	Name="2005 Screwdriver",
-	ViewModel="models/doctor_who/sonic_screwdriver/c_10thsonicsd.mdl",
-	WorldModel="models/doctor_who/sonic_screwdriver/w_10thsonicsd.mdl",
-	LightPos=Vector(20,-2.5,-3.15),
-	LightBrightness=2,
+	ID = "10th-slogan",
+	Name = "2005 Screwdriver",
+	ViewModel = "models/doctor_who/sonic_screwdriver/c_10thsonicsd.mdl",
+	WorldModel = "models/doctor_who/sonic_screwdriver/w_10thsonicsd.mdl",
+	LightPos = Vector(20,-2.5,-3.15),
+	LightBrightness = 2,
 	DefaultLightColor = Color(0, 180, 200)
 })
 
 SonicSD:AddSonic({
-	ID="4th-slogan",
-	Name="1968 Screwdriver",
-	ViewModel="models/doctor_who/sonic_screwdriver/c_4thsonicsd.mdl",
-	WorldModel="models/doctor_who/sonic_screwdriver/w_4thsonicsd.mdl",
+	ID = "4th-slogan",
+	Name = "1968 Screwdriver",
+	ViewModel = "models/doctor_who/sonic_screwdriver/c_4thsonicsd.mdl",
+	WorldModel = "models/doctor_who/sonic_screwdriver/w_4thsonicsd.mdl",
 	LightDisabled = true
 })

--- a/lua/weapons/swep_sonicsd/modules/cl_light.lua
+++ b/lua/weapons/swep_sonicsd/modules/cl_light.lua
@@ -46,3 +46,14 @@ SWEP:AddHook("PreDrawViewModel", "light", function(self,vm,ply,wep,keydown1,keyd
 		end
 	end
 end)
+
+SWEP:AddHook("SonicChanged", "default-color", function(self)
+	if GetConVar("sonic_should_set_default_colors"):GetBool() then
+		local son = self:GetSonic()
+		if son ~= nil and self:GetSonic().DefaultLightColor ~= nil then
+			GetConVar("sonic_light_r"):SetInt(son.DefaultLightColor.r)
+			GetConVar("sonic_light_g"):SetInt(son.DefaultLightColor.g)
+			GetConVar("sonic_light_b"):SetInt(son.DefaultLightColor.b)
+		end
+	end
+end)

--- a/lua/weapons/swep_sonicsd/shared.lua
+++ b/lua/weapons/swep_sonicsd/shared.lua
@@ -5,9 +5,10 @@ SWEP.Author             = "Dr. Matt"
 SWEP.Contact            = "mattjeanes23@gmail.com"
 SWEP.Purpose            = "Opening doors"
 SWEP.Instructions       = "Point and press"
-SWEP.Category			= "Doctor Who - Sonic Tools"
 ------------------------------------------------
- 
+
+SWEP.Category = DEBUG_SONICSD_SPAWNMENU_CATEGORY_OVERRIDE or "Doctor Who - Sonic Tools"
+
 SWEP.Spawnable = true
 SWEP.AdminSpawnable = true
 


### PR DESCRIPTION
Personally, I am extremely annoyed when I click on some canonical sonic, and it has a weird light color from a previous one
Now, sonics can have "default colors"

There is a checkbox/convar that enables/disables the default colors:
изображение

If they are enabled, when you get a sonic, its colors are automatically set as default ones
If disabled, works as before