### PR TITLE
Door locking/unlocking fixed for DarkRP & improvement to prop functionality

### DIFF
--- a/lua/weapons/swep_sonicsd/modules/sv_doors.lua
+++ b/lua/weapons/swep_sonicsd/modules/sv_doors.lua
@@ -15,7 +15,6 @@ SWEP:AddFunction(function(self,data)
         local savetable = data.ent:GetSaveTable()
         local open=(not tobool(savetable.m_toggle_state))
         local locked=tobool(savetable.m_bLocked)
-        print(locked)
         if locked and data.keydown2 and (DarkRP or data.hooks.cantool) then
             data.ent:Fire("Unlock", 0)
             data.ent:EmitSound("doors/door_latch3.wav")

--- a/lua/weapons/swep_sonicsd/modules/sv_doors.lua
+++ b/lua/weapons/swep_sonicsd/modules/sv_doors.lua
@@ -15,11 +15,12 @@ SWEP:AddFunction(function(self,data)
         local savetable = data.ent:GetSaveTable()
         local open=(not tobool(savetable.m_toggle_state))
         local locked=tobool(savetable.m_bLocked)
-        if locked and data.keydown2 and data.hooks.cantool then
+        print(locked)
+        if locked and data.keydown2 and (DarkRP or data.hooks.cantool) then
             data.ent:Fire("Unlock", 0)
             data.ent:EmitSound("doors/door_latch3.wav")
             self.Owner:ChatPrint("Door unlocked.")
-        elseif not locked and data.keydown2 and data.hooks.cantool then
+        elseif not locked and data.keydown2 and (DarkRP or data.hooks.cantool) then
             data.ent:Fire("Lock", 0)
             data.ent:EmitSound("doors/door_latch3.wav")
             self.Owner:ChatPrint("Door locked.")

--- a/lua/weapons/swep_sonicsd/modules/sv_props.lua
+++ b/lua/weapons/swep_sonicsd/modules/sv_props.lua
@@ -10,7 +10,16 @@ SWEP:AddFunction(function(self,data)
     if (data.class=="prop_physics" or data.class=="prop_physics_multiplayer") and data.hooks.canmove then
         local phys=data.ent:GetPhysicsObject()
         if IsValid(phys) then
-            phys:AddVelocity(self.Owner:GetAimVector()*200)
+            local multiplier
+            if data.keydown1 then
+                multiplier = 200
+            elseif data.keydown2 then
+                multiplier = -200
+            end
+
+            if multiplier ~= nil then
+                phys:AddVelocity(self.Owner:GetAimVector()*multiplier)
+            end
         end
         if (data.ent:GetSaveTable().max_health > 1) and data.hooks.cantool then
             data.ent:Fire("Break", 0)


### PR DESCRIPTION
Previously, the sonic screwdriver could not lock or unlock the door on DarkRP due to cantool variable.

I've also done improvements to the prop pushing functionality, allowing the user to now be able to push as well as pull, depending on the keydown.