### PR TITLE
Fixed texture for 10th sonic

### DIFF
--- a/materials/doctor_who/sonic_screwdriver/sonic screwdriver.vmt
+++ b/materials/doctor_who/sonic_screwdriver/sonic screwdriver.vmt
@@ -2,5 +2,5 @@
 {
 	"$basetexture" "Doctor_Who/Sonic_Screwdriver/Sonic Screwdriver"
 	"$surfaceprop" "metal"
-	"$bumpmap" "Doctor_Who/normals/Sonic_Screwdriver/Sonic_Screwdriver_NRM"
+	//"$bumpmap" "Doctor_Who/normals/Sonic_Screwdriver/Sonic_Screwdriver_NRM"
 }


### PR DESCRIPTION
I would rather have those two additional ones removed (or moved to a separate addon like old default interior of the TARDIS)

However, if we have to keep them, we'd better fix the textures