### PR TITLE
Added hold abilities

### DIFF
--- a/lua/weapons/swep_sonicsd/init.lua
+++ b/lua/weapons/swep_sonicsd/init.lua
@@ -42,8 +42,9 @@ function SWEP:Go(ent, trace, keydown1, keydown2)
         hooks.cantool=hook.Call("CanTool", GAMEMODE, self.Owner, self.Owner:GetEyeTraceNoCursor(), "")
     end
     local class=ent:GetClass()
+    self.data = {class=class,ent=ent,hooks=hooks,keydown1=keydown1,keydown2=keydown2,trace=trace}
     for k,v in ipairs(self.functions) do
-        v(self,{class=class,ent=ent,hooks=hooks,keydown1=keydown1,keydown2=keydown2,trace=trace})
+        v(self,self.data)
     end
 end
 
@@ -118,12 +119,16 @@ function SWEP:Think()
                     self.done=nil
                     self.wait=nil
                     self.ent=nil
+                    self.data=nil
+                elseif self.done and self.data then
+                    self:CallHook("Hold", self.data)
                 end
             end
         else
             self.done=nil
             self.wait=nil
             self.ent=nil
+            self.data=nil
         end
         
         self:CallHook("Think",keydown1,keydown2)

--- a/lua/weapons/swep_sonicsd/modules/sh_doctorwho.lua
+++ b/lua/weapons/swep_sonicsd/modules/sh_doctorwho.lua
@@ -164,7 +164,7 @@ if SERVER then
                             TARDIS:Message(self.Owner, "TARDIS unlocked.")
                         end
                     end
-                end)
+                end, true)
             end
         end
     end)

--- a/lua/weapons/swep_sonicsd/modules/sh_doctorwho.lua
+++ b/lua/weapons/swep_sonicsd/modules/sh_doctorwho.lua
@@ -199,6 +199,15 @@ if SERVER then
             end
         end
     end)
+
+    SWEP:AddHook("Hold", "doctorwho", function(self,data)
+        if data.class=="gmod_time_distortion_generator" then
+            if (not self.repairtick) or CurTime() > self.repairtick then
+                self.repairtick = CurTime() + 1
+                data.ent:Repair(20)
+            end 
+        end
+    end)
 else
     function SWEP:PointingAt(ent)
         if not IsValid(ent) then return end


### PR DESCRIPTION
Added the ability to hold on certain entities to perform a continuous action. The first implementation of this is used to repair the Time Distortion Generator in the TARDIS addon.

There was also a small tweak needed for a change to locked door behaviour in the TARDIS addon.